### PR TITLE
Remove confirm dialogs to prevent revalidation bug

### DIFF
--- a/src/actual-pages/JobPage/MainContent.tsx
+++ b/src/actual-pages/JobPage/MainContent.tsx
@@ -76,14 +76,7 @@ export function MainContent({ fullJob, setFullJob, profiles }: Props) {
   };
 
   const deleteResume = async (resume: Resume) => {
-    if (
-      !confirm(
-        `"${
-          resume.resumeName || t.resumeNamePlaceholder
-        }" will be deleted. Continue?`
-      )
-    )
-      return;
+    // TODO: Show confirmation modal.
     setFullJob({
       ...fullJob,
       resumes: fullJob.resumes.filter((r) => r.id !== resume.id),

--- a/src/actual-pages/JobsPage/MainContent.tsx
+++ b/src/actual-pages/JobsPage/MainContent.tsx
@@ -26,12 +26,7 @@ export function MainContent({ jobsWithLinks, setJobsWithLinks }: Props) {
   };
 
   const deleteJob = async (job: Job) => {
-    if (
-      !confirm(
-        `"${job.title || t.jobTitlePlaceholder}" will be deleted. Continue?`
-      )
-    )
-      return;
+    // TODO: Show confirmation modal.
     setJobsWithLinks(jobsWithLinks.filter((j) => j.id !== job.id));
     const response = await fetch(`/api/jobs/${job.pid}`, { method: "DELETE" });
     if (!response.ok) {

--- a/src/actual-pages/ProfilesPage/MainContent.tsx
+++ b/src/actual-pages/ProfilesPage/MainContent.tsx
@@ -1,7 +1,6 @@
 import { FormEvent } from "react";
 import { ProfileOverview } from "./ProfileOverview";
 import { SectionHeading } from "@/components/SectionHeading";
-import { t } from "@/translate";
 import { Profile } from "@/generated/prisma";
 
 type Props = {
@@ -28,14 +27,7 @@ export function MainContent({ profiles, setProfiles }: Props) {
   };
 
   const deleteProfile = async (profile: Profile) => {
-    if (
-      !confirm(
-        `"${
-          profile.profileName || t.profileNamePlaceholder
-        }" will be deleted. Continue?`
-      )
-    )
-      return;
+    // TODO: Show confirmation modal.
     setProfiles(profiles.filter((p) => p.id !== profile.id));
     const response = await fetch(`/api/profiles/${profile.pid}`, {
       method: "DELETE",


### PR DESCRIPTION
Clicking OK on the confirmation dialog triggers an SWR revalidation, which may request data from the server prior to the delete being processed, causing the deleted item to reappear in the UI. This won't happen when using a React modal component in the future.

This PR removes calls to the built-in `confirm` function. A confirmation component will be added in the future.